### PR TITLE
Fix PythonOCC >=7.8.0 compatibility in serialize_shape function

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+import inspect
 import random
 import operator
 import warnings
@@ -225,10 +226,24 @@ def serialize_shape(shape):
     shapes.SetFormatNb(2)
 
     shapes.Add(shape)
+    
+    # Check if WriteToString method exists and has the correct signature
+    # In PythonOCC >= 7.8.0, WriteToString signature changed and requires additional arguments
     if hasattr(shapes, "WriteToString"):
-        return shapes.WriteToString()
-    else:
-        return shapes.Write()
+        try:
+            # Try to get the method signature
+            sig = inspect.signature(shapes.WriteToString)
+            # If WriteToString has no parameters (just self), use it
+            # This works for PythonOCC < 7.8.0
+            if len(sig.parameters) == 0:
+                return shapes.WriteToString()
+        except (ValueError, TypeError):
+            # If signature inspection fails, fall through to Write() method
+            pass
+    
+    # Fall back to Write() method for newer PythonOCC versions (>= 7.8.0)
+    # or when WriteToString is not available/compatible
+    return shapes.Write()
 
 
 def create_shape_from_serialization(

--- a/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
@@ -226,7 +226,7 @@ def serialize_shape(shape):
     shapes.SetFormatNb(2)
 
     shapes.Add(shape)
-    
+
     # Check if WriteToString method exists and has the correct signature
     # In PythonOCC >= 7.8.0, WriteToString signature changed and requires additional arguments
     if hasattr(shapes, "WriteToString"):
@@ -240,7 +240,7 @@ def serialize_shape(shape):
         except (ValueError, TypeError):
             # If signature inspection fails, fall through to Write() method
             pass
-    
+
     # Fall back to Write() method for newer PythonOCC versions (>= 7.8.0)
     # or when WriteToString is not available/compatible
     return shapes.Write()


### PR DESCRIPTION
## Summary
Resolves issue #6099: PythonOCC >=7.8.0 changed `WriteToString()` method signature, causing `TypeError` in `ifcopenshell.geom.serialise()`.

## Changes
- Enhanced `serialize_shape()` function with signature inspection approach
- Added backward compatibility for PythonOCC < 7.8.0 (uses `WriteToString()`)
- Added forward compatibility for PythonOCC >= 7.8.0 (falls back to `Write()`)
- Graceful error handling for signature inspection failures

## Technical Details
The issue occurred because PythonOCC >= 7.8.0 changed the `BRepTools_ShapeSet.WriteToString()` method signature from no parameters to requiring a shape parameter. This fix uses Python's `inspect.signature()` to detect the method signature and choose the appropriate approach automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)